### PR TITLE
fix: use explicit listen header state

### DIFF
--- a/src/features/listen/listenService.js
+++ b/src/features/listen/listenService.js
@@ -433,6 +433,11 @@ class ListenService {
         const { windowPool, updateLayout, getPillWindow } = require('../../window/windowManager');
         const listenWindow = windowPool.get('listen');
         const header = getPillWindow();
+        const nextHeaderStateByAction = {
+            Listen: 'inSession',
+            Stop: 'afterSession',
+            Done: 'beforeSession',
+        };
 
         logger.info('[SEARCH] DEBUG: Windows obtained:', {
             listenWindow: !!listenWindow,
@@ -494,7 +499,10 @@ class ListenService {
             }
 
             logger.info('[SEARCH] DEBUG: About to send listen:changeSessionResult success to header');
-            header.webContents.send('listen:changeSessionResult', { success: true });
+            header.webContents.send('listen:changeSessionResult', {
+                success: true,
+                state: nextHeaderStateByAction[listenButtonText] || 'beforeSession',
+            });
             logger.info('[SEARCH] DEBUG: listen:changeSessionResult success sent successfully');
 
         } catch (error) {

--- a/src/ui/react/MainHeader.jsx
+++ b/src/ui/react/MainHeader.jsx
@@ -644,13 +644,15 @@ export default function MainHeader({
     const onAuthFailed = () => setIsAuthenticating(false);
     window.api.on?.('auth-failed', onAuthFailed);
 
-    const onSession = (_, { success }) => {
+    const onSession = (_, { success, state }) => {
       if (success) {
-        setListenSessionStatus(prev => {
-          const next = ({ beforeSession:'inSession', inSession:'afterSession', afterSession:'beforeSession' })[prev] || 'beforeSession';
-          if (prev === 'afterSession') { setAgentModeActive(false); window.api?.mainHeader?.setAgentMode(false); setIsPaused(false); }
-          return next;
-        });
+        const next = ['beforeSession', 'inSession', 'afterSession'].includes(state) ? state : 'beforeSession';
+        setListenSessionStatus(next);
+        if (next === 'beforeSession') {
+          setAgentModeActive(false);
+          window.api?.mainHeader?.setAgentMode(false);
+          setIsPaused(false);
+        }
       } else {
         setListenSessionStatus('beforeSession');
         setAgentModeActive(false);


### PR DESCRIPTION
## Summary
- Send an explicit header session state with each successful listen session action.
- Update `MainHeader` to apply the provided state directly instead of cycling local state on every success event.
- Reset pause and agent mode only when returning to `beforeSession`.

## Verification
- `npm run build:ui` succeeded.

auto-generated by Codex